### PR TITLE
Fix could not open modal after D&D

### DIFF
--- a/app/views/issues_panel/index.html.erb
+++ b/app/views/issues_panel/index.html.erb
@@ -92,7 +92,7 @@ function loadDroppableSetting() {
     }
   });
 }
-$(document).ready(function(){
+function loadCardFunctions(){
   $('.link-issue').dblclick(function() {
     var issue_id = $(this).attr('data-issue-id');
     window.location.href='<%= issues_path %>/' + issue_id;
@@ -114,7 +114,10 @@ $(document).ready(function(){
       }
     });
   });
+}
+$(document).ready(function(){
   loadDraggableSettings();
   loadDroppableSetting();
+  loadCardFunctions();
 });
 <% end %>

--- a/app/views/issues_panel/move_issue_card.js.erb
+++ b/app/views/issues_panel/move_issue_card.js.erb
@@ -15,6 +15,7 @@
   <% end %>
   // restore background-color
   $('#issue-<%= @issue_card.id %>').addClass('context-menu-selection cm-last', 500);
+  loadCardFunctions();
   loadDraggableSettings();
 <% else %>
   <% if flash[:error].present? %>


### PR DESCRIPTION
Fixed a bug that the issue creation modal dialog did not open in the status after D&D issue.