### PR TITLE
Link status lanes to filtered tracker conditions

### DIFF
--- a/test/unit/issue_query_test.rb
+++ b/test/unit/issue_query_test.rb
@@ -1,6 +1,8 @@
 require File.expand_path('../../test_helper', __FILE__)
 
 class IssueQueryTest < ActiveSupport::TestCase
+  fixtures :roles, :trackers, :issue_statuses
+
   def test_build_from_params_should_set_issues_num_per_row
     q = IssueQuery.create!(:name => 'issue panel', :options => {})
 


### PR DESCRIPTION
This PR is in response to feedback sent by @salmanmp in Issue #39.
When tracker conditions are set in the issue panel filters, the status lane will be displayed based on the workflow that matches the tracker conditions.