### PR TITLE
Unified label expression for query edit buttons

### DIFF
--- a/app/views/issues_panel/_query_form.html.erb
+++ b/app/views/issues_panel/_query_form.html.erb
@@ -70,14 +70,15 @@
   <%= link_to l(:button_clear), { :set_filter => 1, :sort => '', :project_id => @project }, :class => 'icon icon-reload'  %>
   <% if @query.new_record? %>
     <% if User.current.allowed_to?(:save_queries, @project, :global => true) %>
-      <%= link_to_function l(:button_save),
+      <%= link_to_function l(:button_save_object, object_name: l(:label_query).downcase),
                            "$('#query_type').prop('disabled',false);$('#query_form').attr('action', '#{ @project ? new_project_query_path(@project) : new_query_path }').submit()",
                            :class => 'icon icon-save' %>
     <% end %>
   <% else %>
     <% if @query.editable_by?(User.current) %>
-      <%= link_to l(:button_edit), edit_query_path(@query, :issues_panel => 1), :class => 'icon icon-edit' %>
-      <%= delete_link query_path(@query, :issues_panel => 1) %>
+      <% redirect_params = {:issues_panel => 1} %>
+      <%= link_to l(:button_edit_object, object_name: l(:label_query).downcase), edit_query_path(@query, redirect_params), :class => 'icon icon-edit' %>
+      <%= delete_link query_path(@query, redirect_params), {}, l(:button_delete_object, object_name: l(:label_query).downcase) %>
     <% end %>
   <% end %>
 </p>


### PR DESCRIPTION
It's a PR to fix the problem of inconsistent expressions between Redmica itself and the buttons on the query form.