### PR TITLE
Add GitHub Action worlflow for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - redmine-repository: 'redmica/redmica'
+            redmine-version: 'stable-2.4'
+            ruby-version: '3.2'
+          - redmine-repository: 'redmica/redmica'
+            redmine-version: 'master'
+            ruby-version: '3.2'
+          - redmine-repository: 'redmine/redmine'
+            redmine-version: 'master'
+            ruby-version: '3.2'
+
+    steps:
+    - uses: hidakatsuya/action-setup-redmine@v1
+      with:
+        repository: ${{ matrix.redmine-repository }}
+        version: ${{ matrix.redmine-version }}
+        ruby-version: ${{ matrix.ruby-version }}
+        database: 'postgres:14'
+
+    - uses: actions/checkout@v4
+      with:
+        path: plugins/redmine_issues_panel
+
+    - run: bin/rails redmine:plugins:test NAME=redmine_issues_panel


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow for testing.

The workflow is configured to:

* Set up Redmine using [hidakatsuya/action-setup-redmine](https://github.com/hidakatsuya/action-setup-redmine).
* Test against RedMica master, latest stable, and Redmine master.
* Use PostgreSQL v14 as the database ([the official recommended version](https://www.redmine.org/projects/redmine/wiki/RedmineInstall)).

I have run the workflow in the forked repository, verified that it executes successfully, and confirmed that all tests pass.
https://github.com/hidakatsuya/redmine_issues_panel/actions/runs/9263231109