### PR TITLE
Change to display issue description on mouseover

### DIFF
--- a/app/controllers/issues_panel_controller.rb
+++ b/app/controllers/issues_panel_controller.rb
@@ -16,7 +16,11 @@ class IssuesPanelController < ApplicationController
   end
 
   def show_issue_description
-    render :layout => false
+    if flash[:error].nil?
+      render json: { description: render_to_string(partial: 'issues_panel/show_issue_description', locals: { issue_card: @issue_card }) }
+    else
+      render json: { error_message: flash[:error] }
+    end
   end
 
   def move_issue_card

--- a/app/views/issues_panel/_show_issue_description.html.erb
+++ b/app/views/issues_panel/_show_issue_description.html.erb
@@ -1,0 +1,22 @@
+<div class="<%= issue_card.css_classes %> details">
+  <div class="gravatar-with-child">
+    <%= author_avatar(issue_card.author, :size => "50") %>
+    <%= assignee_avatar(issue_card.assigned_to, :size => "22", :class => "gravatar-child") if issue_card.assigned_to %>
+  </div>
+  <div class="subject">
+    <%= render_issue_subject_with_tree(issue_card) %>
+  </div>
+  <p class="author">
+    <%= authoring issue_card.created_on, issue_card.author %>.
+    <% if issue_card.created_on != issue_card.updated_on %>
+    <%= l(:label_updated_time, time_tag(issue_card.updated_on)).html_safe %>.
+  <% end %>
+  </p>
+  <hr />
+  <div class="description">
+    <p><strong><%=l(:field_description)%></strong></p>
+    <div class="wiki">
+      <%= textilizable(issue_card.description.truncate(200)) %>
+    </div>
+  </div>
+</div>

--- a/app/views/issues_panel/_show_issue_description.html.erb
+++ b/app/views/issues_panel/_show_issue_description.html.erb
@@ -9,8 +9,8 @@
   <p class="author">
     <%= authoring issue_card.created_on, issue_card.author %>.
     <% if issue_card.created_on != issue_card.updated_on %>
-    <%= l(:label_updated_time, time_tag(issue_card.updated_on)).html_safe %>.
-  <% end %>
+      <%= l(:label_updated_time, time_tag(issue_card.updated_on)).html_safe %>.
+    <% end %>
   </p>
   <hr />
   <div class="description">

--- a/app/views/issues_panel/index.html.erb
+++ b/app/views/issues_panel/index.html.erb
@@ -141,7 +141,7 @@ function hideIssueDescription() {
   $('#issue_panel_issue_description').hide();
 }
 function loadCardFunctions(){
-$('.issue-card a.issue').mouseover(function(event) {
+  $('.issue-card a.issue').mouseover(function(event) {
     var element = $(this);
     var issue_id = element.closest('.issue-card').data('issue-id')
     showIssueDescription(issue_id, element);

--- a/app/views/issues_panel/index.html.erb
+++ b/app/views/issues_panel/index.html.erb
@@ -94,18 +94,18 @@ function loadDroppableSetting() {
     }
   });
 }
-function showIssueDescription(issue_id, element) {
-  var mouse_x = element.offset().left;
-  var mouse_y = element.offset().top;
-  var description_element = $('#issue_panel_issue_description');
+function showIssueDescription(issue_element, description_element) {
+  var issue_id = issue_element.attr('href').split('/').at(-1)
+  var mouse_x = issue_element.offset().left;
+  var mouse_y = issue_element.offset().top;
 
   description_element.css('left', (mouse_x + 'px'));
   description_element.css('top', (mouse_y + 'px'));
   description_element.html('');
 
   $.ajax({
-    url: '<%= show_issue_description_path(:format => 'js') %>',
-    data: { 'id': issue_id },
+    url: '<%= show_issue_description_path %>',
+    data: { 'id': issue_id},
     success: function(data) {
       if (data['description'] !== undefined && data['description'] != '') {
         description_element.html(data['description']);
@@ -142,9 +142,7 @@ function hideIssueDescription() {
 }
 function loadCardFunctions(){
   $('.issue-card a.issue').mouseover(function(event) {
-    var element = $(this);
-    var issue_id = element.closest('.issue-card').data('issue-id')
-    showIssueDescription(issue_id, element);
+    showIssueDescription($(this), $('#issue_panel_issue_description'));
   });
   $('.issue-card a.issue').mouseout(function() {
     hideIssueDescription();

--- a/app/views/issues_panel/index.html.erb
+++ b/app/views/issues_panel/index.html.erb
@@ -33,10 +33,7 @@
 
 <%= context_menu %>
 
-<div id="issue_panel_issue_description" class="wiki">
-  <h4><%= l(:field_description) %></h4>
-  <div id="description_content"></div>
-</div>
+<div id="issue_panel_issue_description"></div>
 
 <div id="new-issue-card-modal" style="display:none;"></div>
 
@@ -97,20 +94,60 @@ function loadDroppableSetting() {
     }
   });
 }
-function loadCardFunctions(){
-  $('.show-issue-description').click(function(event) {
-    // clear context menu selection
-    contextMenuUnselectAll();
-    contextMenuHide();
-    var target = $(event.target);
-    var tr = target.closest('.hascontextmenu').first();
-    contextMenuAddSelection(tr);
+function showIssueDescription(issue_id, element) {
+  var mouse_x = element.offset().left;
+  var mouse_y = element.offset().top;
+  var description_element = $('#issue_panel_issue_description');
 
-    var issue_id = $(this).attr('data-issue-id')
-    var mouse_x = event.pageX;
-    var mouse_y = event.pageY;
-    showIssueDescription(issue_id, mouse_x, mouse_y);
-    return false;
+  description_element.css('left', (mouse_x + 'px'));
+  description_element.css('top', (mouse_y + 'px'));
+  description_element.html('');
+
+  $.ajax({
+    url: '<%= show_issue_description_path(:format => 'js') %>',
+    data: { 'id': issue_id },
+    success: function(data) {
+      if (data['description'] !== undefined && data['description'] != '') {
+        description_element.html(data['description']);
+        var description_width = description_element.width();
+        var description_height = description_element.height();
+
+        // modify position if the description element is out of window
+        var render_x = mouse_x - 90;
+        var render_y = mouse_y - description_height - 16;
+
+        var window_width = window_size().width;
+        if ((render_x + description_width) > window_width) {
+          render_x = window_width - description_width - 18;
+        }
+        if (render_y < $(window).scrollTop()) {
+          render_y = mouse_y + 18;
+        }
+        if (render_x <= 0) { render_x = 1; }
+        if (render_y <= 0) { render_y = 1; }
+
+        // show description element
+        description_element.css('left', (render_x + 'px'));
+        description_element.css('top', (render_y + 'px'));
+        description_element.show();
+      } else {
+        if (data['error_message'] !== undefined && data['error_message'] != '') { alert(data['error_message']); }
+      }
+    }
+  });
+}
+function hideIssueDescription() {
+  $('#issue_panel_issue_description #description_content').html('');
+  $('#issue_panel_issue_description').hide();
+}
+function loadCardFunctions(){
+$('.issue-card a.issue').mouseover(function(event) {
+    var element = $(this);
+    var issue_id = element.closest('.issue-card').data('issue-id')
+    showIssueDescription(issue_id, element);
+  });
+  $('.issue-card a.issue').mouseout(function() {
+    hideIssueDescription();
   });
   $('.link-issue').dblclick(function() {
     var issue_id = $(this).attr('data-issue-id');
@@ -133,18 +170,6 @@ function loadCardFunctions(){
       }
     });
   });
-}
-function showIssueDescription(issue_id, left, top) {
-  $('#issue_panel_issue_description').css('left', (left + 'px'));
-  $('#issue_panel_issue_description').css('top', (top + 'px'));
-  $.ajax({
-    url: '<%= show_issue_description_path(:format => 'js') %>',
-    data: { 'id': issue_id }
-  });
-}
-function hideIssueDescription() {
-  $('#issue_panel_issue_description #description_content').html('');
-  $('#issue_panel_issue_description').hide();
 }
 $(document).ready(function(){
   loadDraggableSettings();

--- a/app/views/issues_panel/show_issue_description.js.erb
+++ b/app/views/issues_panel/show_issue_description.js.erb
@@ -1,8 +1,0 @@
-<% if flash[:error].present? %>
-  alert('<%= raw(escape_javascript(flash[:error])) %>');
-<% else %>
-  <% if @issue_card.description.present? %>
-    $('#issue_panel_issue_description #description_content').html('<%= escape_javascript(textilizable(@issue_card, :description, :attachments => @issue_card.attachments)) %>');
-    $('#issue_panel_issue_description').show();
-  <% end %>
-<% end %>

--- a/assets/stylesheets/redmine_issues_panel.css
+++ b/assets/stylesheets/redmine_issues_panel.css
@@ -23,25 +23,19 @@ table.issues-panel td {
 }
 
 div#issue_panel_issue_description {
-  background-color: #ffffdd;
+  background-color: #ffffee;
+  padding-top: 6px;
   padding-left: 6px;
   padding-right: 6px;
   position: absolute;
   z-index: 1000;
-  min-width: 300px;
-  max-width: 600px;
-  border: 1px solid #507AAA;
-  display: none;
-}
-
-div#issue_panel_issue_description img {
-  min-width: 260px!important;
-  max-width: 520px!important;
-}
-
-div#issue_panel_issue_description div#description_content {
+  width: 500px;
   max-height: 300px;
-  overflow: scroll;
+  overflow: hidden;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  box-shadow: 0 0 1px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.2);
+  display: none;
 }
 
 .issue-card-receiver {

--- a/lib/redmine/helpers/issues_panel.rb
+++ b/lib/redmine/helpers/issues_panel.rb
@@ -161,22 +161,20 @@ module Redmine
 
       def render_card_content(issue)
         issue = issue.becomes(IssueCard)
-        description_button = issue.description.present? ? view.link_to(l(:field_description), '#', :title => l(:field_description), :class => 'icon-only icon-document show-issue-description', :data => { :issue_id => issue.id }) : ''
         view.content_tag('div',
           view.content_tag('div',
             view.content_tag('input', nil, :type => 'checkbox', :name => 'ids[]', :value => issue.id, :style => 'display:none;', :class => 'toggle-selection').html_safe +
             view.content_tag('div',
               view.link_to_context_menu.html_safe +
-              view.link_to_issue(issue, :tracker => true, :subject => false).html_safe,
+              view.link_to("#{issue.tracker} ##{issue.id}", issue_url(issue, :only_path => true), :class => issue.css_classes).html_safe,
               :class => 'header clear'
             ).html_safe +
             @query.inline_columns.collect do |column|
               render_column_content(column, issue)
             end.join.html_safe +
             view.content_tag('div',
-              description_button.html_safe +
               view.watcher_link(issue.becomes(Issue), User.current),
-              :class => 'footer clear').html_safe, 
+              :class => 'footer clear').html_safe,
             :class => "card-content"),
           :id => "issue-#{issue.id}",
           :class => "hascontextmenu #{issue.priority.try(:css_classes)} #{issue.overdue? ? 'overdue' : ''} #{issue.closed? ? 'closed' : ''}"


### PR DESCRIPTION
This pull request adds functionality to display issue description when the 'mouseover' an issue card on the panel.
The feature enhancement allows users to quickly view issue description by simply moving the mouse over an issue, improving user experience and efficiency.