### PR TITLE
Improve issue description UX

### DIFF
--- a/app/views/issues_panel/_show_issue_description.html.erb
+++ b/app/views/issues_panel/_show_issue_description.html.erb
@@ -1,22 +1,11 @@
-<div class="<%= issue_card.css_classes %> details">
-  <div class="gravatar-with-child">
-    <%= author_avatar(issue_card.author, :size => "50") %>
-    <%= assignee_avatar(issue_card.assigned_to, :size => "22", :class => "gravatar-child") if issue_card.assigned_to %>
-  </div>
+<div class="issue">
   <div class="subject">
-    <%= render_issue_subject_with_tree(issue_card) %>
+    <%= link_to_issue(issue_card, :tracker => false, :subject => true) %>
   </div>
-  <p class="author">
-    <%= authoring issue_card.created_on, issue_card.author %>.
-    <% if issue_card.created_on != issue_card.updated_on %>
-      <%= l(:label_updated_time, time_tag(issue_card.updated_on)).html_safe %>.
-    <% end %>
-  </p>
   <hr />
   <div class="description">
-    <p><strong><%=l(:field_description)%></strong></p>
     <div class="wiki">
-      <%= textilizable(issue_card.description.truncate(200)) %>
+      <%= textilizable(issue_card.description.truncate(200), :headings => false) %>
     </div>
   </div>
 </div>

--- a/app/views/issues_panel/index.html.erb
+++ b/app/views/issues_panel/index.html.erb
@@ -137,14 +137,23 @@ function showIssueDescription(issue_element, description_element) {
   });
 }
 function hideIssueDescription() {
-  $('#issue_panel_issue_description #description_content').html('');
+  $('#issue_panel_issue_description').html('');
   $('#issue_panel_issue_description').hide();
 }
 function loadCardFunctions(){
-  $('.issue-card a.issue').mouseover(function(event) {
+  var timer;
+  $('.issue-card .card-content .subject a').mouseover(function(event) {
+    clearTimeout(timer);
     showIssueDescription($(this), $('#issue_panel_issue_description'));
   });
-  $('.issue-card a.issue').mouseout(function() {
+  $('.issue-card .card-content .subject a').mouseout(function() {
+    timer = setTimeout(function() {
+      if (!$('#issue_panel_issue_description').is(':hover')) {
+        hideIssueDescription();
+      }
+    }, 400);
+  });
+  $('#issue_panel_issue_description').mouseleave(function() {
     hideIssueDescription();
   });
   $('.link-issue').dblclick(function() {

--- a/assets/stylesheets/redmine_issues_panel.css
+++ b/assets/stylesheets/redmine_issues_panel.css
@@ -22,19 +22,77 @@ table.issues-panel td {
   text-align: left;
 }
 
-div#issue_panel_issue_description {
+#issue_panel_issue_description {
   background-color: #ffffee;
-  padding-top: 6px;
-  padding-left: 6px;
-  padding-right: 6px;
+  padding: 3px;
   position: absolute;
   z-index: 1000;
-  width: 500px;
-  max-height: 300px;
-  overflow: hidden;
+  width: 380px;
   border: 1px solid #ddd;
   border-radius: 3px;
   box-shadow: 0 0 1px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.2);
+  display: none;
+}
+
+#issue_panel_issue_description .issue {
+  background-color: #ffffee;
+  border: none;
+  padding: 3px;
+  margin: 3px;
+}
+
+#issue_panel_issue_description .issue .subject {
+  font-size: 0.8em;
+  font-weight: bold;
+}
+
+#issue_panel_issue_description .issue .subject a {
+  padding-left: 0px;
+  margin-left: 0px;
+}
+
+#issue_panel_issue_description .issue .description .wiki * {
+  font-size: 0.9em;
+  font-weight: normal;
+  border: none;
+  margin: 2px;
+  font-style: normal;
+}
+
+#issue_panel_issue_description .issue .description .wiki blockquote {
+  padding-left: 0px;
+}
+
+#issue_panel_issue_description .issue .description .wiki ol,
+#issue_panel_issue_description .issue .description .wiki ul {
+  padding-inline-start: 18px;
+  font-size: 1em;
+}
+
+#issue_panel_issue_description .issue .description .wiki pre,
+#issue_panel_issue_description .issue .description .wiki pre code {
+  padding: 0px;
+  margin: 0px;
+  background: transparent;
+  white-space: pre-wrap;
+  hyphens: auto;
+}
+
+#issue_panel_issue_description .issue .description .wiki pre code span {
+  margin: 0px;
+  color: inherit;
+  background: transparent;
+}
+
+#issue_panel_issue_description .issue .description .wiki table,
+#issue_panel_issue_description .issue .description .wiki tr,
+#issue_panel_issue_description .issue .description .wiki td {
+  padding: 2px;
+  font-size: 1em;
+}
+
+#issue_panel_issue_description .issue .description .wiki p img,
+#issue_panel_issue_description .issue .description .wiki p img+br {
   display: none;
 }
 

--- a/test/functional/issues_panel_controller_test.rb
+++ b/test/functional/issues_panel_controller_test.rb
@@ -173,9 +173,8 @@ class IssuesPanelControllerTest < ActionController::TestCase
     assert_equal 'application/json', response.media_type
     data = ActiveSupport::JSON.decode(response.body)
     assert_select(Nokogiri::HTML(data['description']), "div.issue") do
-      assert_select 'div.subject', issue.subject
+      assert_select 'div.subject', "##{issue.id}: #{issue.subject}"
       assert_select 'div.description' do
-        assert_select 'p strong', I18n.t(:field_description)
         assert_select 'div.wiki', issue.description
       end
     end


### PR DESCRIPTION
This PR improves the UX added in #56 in the following ways
* Change the mouse-over location: changed from the issue number to the issue subject.
* Removed the author and assignee icons and the creation date information.
* The size of the description has been reduced: The text size has been adjusted to be smaller without excessive decoration.
* Fixed a problem with overflowing text: Removed the max-height limitation.