### PR TITLE
Fix add issue icon does not display

### DIFF
--- a/assets/stylesheets/redmine_issues_panel.css
+++ b/assets/stylesheets/redmine_issues_panel.css
@@ -15,6 +15,16 @@ table.issues-panel th {
   font-weight:bold;
 }
 
+table.issues-panel th span.badge-count {
+  top: -1px;
+}
+
+table.issues-panel th a.add-issue-card {
+  display: inline;
+  position: relative;
+  top: -2px;
+}
+
 table.issues-panel td {
   vertical-align: top;
   background-color: #fffffb;
@@ -140,7 +150,7 @@ table.issues-panel td {
   flex: 1 1 calc(100% / 3.3);
 }
 
-.add-issue-card {
+.issue-cards>.add-issue-card {
   margin: 2px;
   width: 98%;
   text-align: center;


### PR DESCRIPTION
Due to a change in the icon implementation in the latest Redmine master branch, the issue_panel no longer displays the add Issue icon.
This PR resolves this by adjusting the style of the add issue icon.