### PR TITLE
Support for SVG icons in Redmine6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - redmine-repository: 'redmica/redmica'
-            redmine-version: 'stable-3.0'
-            ruby-version: '3.3'
-          - redmine-repository: 'redmica/redmica'
-            redmine-version: 'master'
-            ruby-version: '3.3'
           - redmine-repository: 'redmine/redmine'
             redmine-version: 'master'
             ruby-version: '3.3'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
     strategy:
       matrix:
         include:
+          - redmine-repository: 'redmica/redmica'
+            redmine-version: 'master'
+            ruby-version: '3.3'
           - redmine-repository: 'redmine/redmine'
             redmine-version: 'master'
             ruby-version: '3.3'

--- a/app/views/issues_panel/_modal_form.html.erb
+++ b/app/views/issues_panel/_modal_form.html.erb
@@ -60,7 +60,7 @@
               <%= f.select :category_id, (@issue_card.project.issue_categories.collect {|c| [c.name, c.id]}),
                            {:include_blank => true, :required => @issue_card.required_attribute?('category_id')},
                            :onchange => "updateIssueFrom('#{escape_javascript new_issue_card_path}', this)" %>
-              <%= link_to(l(:label_issue_category_new),
+              <%= link_to(sprite_icon('add',l(:label_issue_category_new)),
                           new_project_issue_category_path(@issue_card.project),
                           :remote => true,
                           :method => 'get',
@@ -75,7 +75,7 @@
             <p>
               <%= f.select :fixed_version_id, version_options_for_select(@issue_card.assignable_versions, @issue_card.fixed_version),
                            :include_blank => true, :required => @issue_card.required_attribute?('fixed_version_id') %>
-              <%= link_to(l(:label_version_new),
+              <%= link_to(sprite_icon('add', l(:label_version_new)),
                           new_project_version_path(@issue_card.project),
                           :remote => true,
                           :method => 'get',

--- a/app/views/issues_panel/_query_form.html.erb
+++ b/app/views/issues_panel/_query_form.html.erb
@@ -5,7 +5,10 @@
 <div id="query_form_with_buttons" class="hide-when-print">
 <div id="query_form_content">
   <fieldset id="filters" class="collapsible <%= @query.new_record? ? "" : "collapsed" %>">
-    <legend onclick="toggleFieldset(this);" class="icon icon-<%= @query.new_record? ? "expended" : "collapsed" %>"><%= l(:label_filter_plural) %></legend>
+    <legend onclick="toggleFieldset(this);" class="icon icon-<%= @query.new_record? ? "expended" : "collapsed" %>">
+      <%= sprite_icon(@query.new_record? ? "angle-down" : "angle-right") %>
+      <%= l(:label_filter_plural) %>
+    </legend>
     <div style="<%= @query.new_record? ? "" : "display: none;" %>">
       <%= render :partial => 'queries/filters', :locals => {:query => @query} %>
     </div>
@@ -13,7 +16,10 @@
 
   <% if @query.available_columns.any? %>
     <fieldset id="options" class="collapsible collapsed">
-      <legend onclick="toggleFieldset(this);" class="icon icon-collapsed"><%= l(:label_options) %></legend>
+      <legend onclick="toggleFieldset(this);" class="icon icon-collapsed">
+        <%= sprite_icon("angle-right") %>
+        <%= l(:label_options) %>
+      </legend>
         <div class="hidden">
           <% if @query.available_display_types.size > 1 %>
           <div>
@@ -66,18 +72,18 @@
 </div>
 
 <p class="buttons">
-  <%= link_to_function l(:button_apply), '$("#query_form").submit()', :class => 'icon icon-checked' %>
-  <%= link_to l(:button_clear), { :set_filter => 1, :sort => '', :project_id => @project }, :class => 'icon icon-reload'  %>
+  <%= link_to_function sprite_icon('checked', l(:button_apply)), '$("#query_form").submit()', :class => 'icon icon-checked' %>
+  <%= link_to sprite_icon('reload', l(:button_clear)), { :set_filter => 1, :sort => '', :project_id => @project }, :class => 'icon icon-reload'  %>
   <% if @query.new_record? %>
     <% if User.current.allowed_to?(:save_queries, @project, :global => true) %>
-      <%= link_to_function l(:button_save_object, object_name: l(:label_query).downcase),
+      <%= link_to_function sprite_icon('save', l(:button_save_object, object_name: l(:label_query).downcase)),
                            "$('#query_type').prop('disabled',false);$('#query_form').attr('action', '#{ @project ? new_project_query_path(@project) : new_query_path }').submit()",
                            :class => 'icon icon-save' %>
     <% end %>
   <% else %>
     <% if @query.editable_by?(User.current) %>
       <% redirect_params = {:issues_panel => 1} %>
-      <%= link_to l(:button_edit_object, object_name: l(:label_query).downcase), edit_query_path(@query, redirect_params), :class => 'icon icon-edit' %>
+      <%= link_to sprite_icon('edit', l(:button_edit_object, object_name: l(:label_query).downcase)), edit_query_path(@query, redirect_params), :class => 'icon icon-edit' %>
       <%= delete_link query_path(@query, redirect_params), {}, l(:button_delete_object, object_name: l(:label_query).downcase) %>
     <% end %>
   <% end %>

--- a/app/views/issues_panel/index.html.erb
+++ b/app/views/issues_panel/index.html.erb
@@ -4,7 +4,7 @@
 
 <div class="contextual">
   <% if User.current.allowed_to?(:add_issues, @project, :global => true) && (@project.nil? || Issue.allowed_target_trackers(@project).any?) %>
-    <%= link_to l(:label_issue_new), _new_project_issue_path(@project, {:params => { :back_url => _project_issues_panel_path(@project) } }), :class => 'icon icon-add new-issue' %>
+    <%= link_to sprite_icon('add', l(:label_issue_new)), _new_project_issue_path(@project, {:params => { :back_url => _project_issues_panel_path(@project) } }), :class => 'icon icon-add new-issue' %>
   <% end %>
 </div>
 

--- a/init.rb
+++ b/init.rb
@@ -6,7 +6,7 @@ Redmine::Plugin.register :redmine_issues_panel do
   name 'Redmine Issues Panel plugin'
   author 'Takenori Takaki (Far End Technologies)'
   description 'A plugin for Redmine to display issues by statuses and change it\'s status by DnD.'
-  requires_redmine version_or_higher: '4.1'
+  requires_redmine version_or_higher: '6.0'
   version '1.0.4'
   url 'https://github.com/redmica/redmine_issues_panel'
   author_url 'https://hosting.redmine.jp/'

--- a/lib/redmine/helpers/issues_panel.rb
+++ b/lib/redmine/helpers/issues_panel.rb
@@ -245,7 +245,7 @@ module Redmine
             end
             if new_issue_params.any?
               issue_cards << view.content_tag('div',
-                               view.link_to(l(:label_issue_new), '', :class => 'icon icon-add new-issue'),
+                               view.link_to(view.sprite_icon('add', l(:label_issue_new)), '', :class => 'icon icon-add new-issue'),
                                :class => "issue-card add-issue-card",
                                :data => { :url => view.new_issue_card_path({ :project_id => @query.project.try(:id), :issue => new_issue_params, :back_url => _project_issues_panel_path(@query.project) }) }
                              )
@@ -275,8 +275,8 @@ module Redmine
                            :id => "issues-count-on-status-#{s.id}",
                            :class => 'badge badge-count count').html_safe +
                           (new_issue && new_issue.new_statuses_allowed_to(User.current).include?(s) ?
-                            view.link_to('', '',
-                              :class => 'icon icon-add new-issue add-issue-card',
+                            view.link_to(view.sprite_icon('add', ''), '',
+                              :class => 'icon-only icon-add new-issue add-issue-card',
                               :data => { :url => view.new_issue_card_path({ :project_id => @query.project.try(:id), :issue => { :status_id => s.id }, :back_url => _project_issues_panel_path(@query.project) }) }
                             ) : '').html_safe
                        )}.join.html_safe

--- a/lib/redmine/helpers/issues_panel.rb
+++ b/lib/redmine/helpers/issues_panel.rb
@@ -291,7 +291,7 @@ module Redmine
           if self.grouped?
             tbody << view.content_tag('tr',
                        view.content_tag('td',
-                         view.content_tag('span', '&nbsp;'.html_safe, :class => 'expander icon icon-expended', :onclick => 'toggleRowGroup(this);').html_safe +
+                         view.content_tag('span', view.sprite_icon("angle-down"), :class => 'expander icon icon-expanded', :onclick => 'toggleRowGroup(this);').html_safe +
                          view.content_tag('span', group_label, :class => 'name').html_safe +
                          view.content_tag('span', group_count, :class => 'badge badge-count count issues-count-on-group', :id => "issues-count-on-group-#{group_css}").html_safe,
                          :colspan => statuses.count


### PR DESCRIPTION
This pull request includes several updates to the user interface and compatibility improvements for the Redmine Issues Panel plugin. The most important changes include the addition of sprite icons to various UI elements and the update of the required Redmine version.

### User Interface Enhancements:

* Added sprite icons to the "New Issue Category" and "New Version" links in the issue modal form (`app/views/issues_panel/_modal_form.html.erb`). [[1]](diffhunk://#diff-fdb8a285a9e63f27dcdf1dd89bd5c38c56e57190277834207687b22ae5d5636cL63-R63) [[2]](diffhunk://#diff-fdb8a285a9e63f27dcdf1dd89bd5c38c56e57190277834207687b22ae5d5636cL78-R78)
* Enhanced the query form by adding sprite icons to the filter and options legends and the apply, clear, save, and edit buttons (`app/views/issues_panel/_query_form.html.erb`). [[1]](diffhunk://#diff-23366a1c6b5bcc3a18c59817b874f72e4d2f81a63e1887924cb64a6523cca1b4L8-R22) [[2]](diffhunk://#diff-23366a1c6b5bcc3a18c59817b874f72e4d2f81a63e1887924cb64a6523cca1b4L69-R86)
* Updated the "New Issue" link in the issues panel index to use a sprite icon (`app/views/issues_panel/index.html.erb`).

### Compatibility Improvements:

* Updated the required Redmine version to 6.0 in the plugin initialization file (`init.rb`).

### Codebase Updates:

* Modified the `render_issue_cards` and `render_issues_panel` methods to include sprite icons for the "New Issue" button (`lib/redmine/helpers/issues_panel.rb`). [[1]](diffhunk://#diff-9e7a9425a2dc3081032e3289cf482f6807a3acc93dcefd56f241317fbb3e7433L248-R248) [[2]](diffhunk://#diff-9e7a9425a2dc3081032e3289cf482f6807a3acc93dcefd56f241317fbb3e7433L278-R279)