### PR TITLE
Add CI environment using RedMica3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         include:
           - redmine-repository: 'redmica/redmica'
+            redmine-version: 'stable-3.1'
+            ruby-version: '3.3'
+          - redmine-repository: 'redmica/redmica'
             redmine-version: 'master'
             ruby-version: '3.3'
           - redmine-repository: 'redmine/redmine'


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/test.yml` file. The change adds a new matrix configuration for testing with the stable version 3.1 of the RedMica repository.

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R14-R16): Added a new matrix configuration for `redmica/redmica` with `redmine-version` set to `stable-3.1` and `ruby-version` set to `3.3`.