### PR TITLE
Fix undefined method 'truncate' for nil

### DIFF
--- a/app/views/issues_panel/_show_issue_description.html.erb
+++ b/app/views/issues_panel/_show_issue_description.html.erb
@@ -5,7 +5,7 @@
   <hr />
   <div class="description">
     <div class="wiki">
-      <%= textilizable(issue_card.description.try(:truncate, 200), :headings => false) %>
+      <%= textilizable(issue_card.description&.truncate(200), :headings => false) %>
     </div>
   </div>
 </div>

--- a/app/views/issues_panel/_show_issue_description.html.erb
+++ b/app/views/issues_panel/_show_issue_description.html.erb
@@ -5,7 +5,7 @@
   <hr />
   <div class="description">
     <div class="wiki">
-      <%= textilizable(issue_card.description.truncate(200), :headings => false) %>
+      <%= textilizable(issue_card.description.try(:truncate, 200), :headings => false) %>
     </div>
   </div>
 </div>

--- a/test/functional/issues_panel_controller_test.rb
+++ b/test/functional/issues_panel_controller_test.rb
@@ -201,4 +201,20 @@ class IssuesPanelControllerTest < ActionController::TestCase
     data = ActiveSupport::JSON.decode(response.body)
     assert_equal I18n.t(:notice_not_authorized_to_change_this_issue), data['error_message']
   end
+
+  def test_show_issue_description_when_description_is_nil
+    issue = Issue.generate!(:description => nil, :author => User.current)
+    get :show_issue_description, :xhr => true, :params => {
+      :id => issue.id
+    }
+    assert_response :success
+    assert_equal 'application/json', response.media_type
+    data = ActiveSupport::JSON.decode(response.body)
+    assert_select(Nokogiri::HTML(data['description']), "div.issue") do
+      assert_select 'div.subject', "##{issue.id}: #{issue.subject}"
+      assert_select 'div.description' do
+        assert_select 'div.wiki', ''
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pull request includes a small change to the `app/views/issues_panel/_show_issue_description.html.erb` file.
The change ensures that the `description` method is safely called using the `try` method to prevent potential errors if `description` is `nil`.