### PR TITLE
Fix watcher list display on issue card

### DIFF
--- a/assets/stylesheets/redmine_issues_panel.css
+++ b/assets/stylesheets/redmine_issues_panel.css
@@ -203,6 +203,26 @@ table.issues-panel td {
   float: left;
   padding-right: 2px;
 }
+.card-content .watcher_users .caption strong {
+  line-height: 0.9em
+}
+.card-content .watcher_users .value ul {
+  display: inline;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+.card-content .watcher_users .value ul li {
+  display: inline;
+}
+.card-content .watcher_users .value ul li::after {
+  content: ",";
+  margin-left: 2px;
+  margin-right: 4px;
+}
+.card-content .watcher_users .value ul li:last-child::after {
+  content: "";
+}
 .card-content .header .js-contextmenu {
   float: right;
 }

--- a/lib/redmine/helpers/issues_panel.rb
+++ b/lib/redmine/helpers/issues_panel.rb
@@ -149,7 +149,7 @@ module Redmine
         when :due_date
           value = view.issue_due_date_details(issue) || ''
         else
-          value = view.column_content(column, issue) || ''
+          value = view.column_content(column, issue.becomes(Issue)) || ''
         end
         view.content_tag('div',
           view.content_tag('div', caption.html_safe, :class => "caption").html_safe +


### PR DESCRIPTION
This pull request includes changes to fix a rendering bug caused by string conversion of model class names and to improve the visual style of the watcher user list. Here is a summary of the most important changes

### Fixes to column content rendering:

* Updated `render_column_content` in `lib/redmine/helpers/issues_panel.rb` so that `IssueCard` objects are converted to `Issue` objects before rendering column content. This solves a problem with the class name string (it evaluates to “view_issue_card_watchers” when it should be “view_issue_watchers”, resulting in a false result and no watcher user list being displayed).

### Improved visual style of watcher user list:

* Added CSS definition to `assets/stylesheets/redmine_issues_panel.css` to style the watcher user list displayed in the Issue Card. delimited string so that it can be displayed as shown in the screenshot below.

<img width="231" alt="image" src="https://github.com/user-attachments/assets/53bc4438-630a-4916-baf7-6b5918c816b2" />