### PR TITLE
Skip test for redmine/redmine master due to plugin incompatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,7 @@ jobs:
       with:
         path: plugins/redmine_issues_panel
 
+    # # Plugins do not work on the redmine/redmine master branch,
+    # so this test combination will be skipped until the issue is fixed.
     - run: bin/rails redmine:plugins:test NAME=redmine_issues_panel
+      if: ${{ !(matrix.redmine-repository == 'redmine/redmine' && matrix.redmine-version == 'master') }}


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/test.yml` file. The change skips a specific test combination for the `redmine_issues_panel` plugin when using the `redmine/redmine` master branch due to compatibility issues.