### PR TITLE
Fix description tooltip flicker

### DIFF
--- a/app/views/issues_panel/index.html.erb
+++ b/app/views/issues_panel/index.html.erb
@@ -141,25 +141,37 @@ function hideIssueDescription() {
   $('#issue_panel_issue_description').hide();
 }
 function loadCardFunctions(){
-  var timer;
+  let closeTimer;
+  let showTimer;
+
   $('.issue-card .card-content .subject a').mouseover(function(event) {
-    clearTimeout(timer);
-    showIssueDescription($(this), $('#issue_panel_issue_description'));
+    const element = $(this);
+    clearTimeout(closeTimer);
+
+    showTimer = setTimeout(function() {
+      showIssueDescription(element, $('#issue_panel_issue_description'));
+    }, 500);
   });
+
   $('.issue-card .card-content .subject a').mouseout(function() {
-    timer = setTimeout(function() {
+    clearTimeout(showTimer);
+
+    closeTimer = setTimeout(function() {
       if (!$('#issue_panel_issue_description').is(':hover')) {
         hideIssueDescription();
       }
     }, 400);
   });
+
   $('#issue_panel_issue_description').mouseleave(function() {
     hideIssueDescription();
   });
+
   $('.link-issue').dblclick(function() {
     var issue_id = $(this).attr('data-issue-id');
     window.location.href='<%= issues_path %>/' + issue_id;
   });
+
   $('.add-issue-card').click(function(e) {
     e.preventDefault();
     $.ajax({

--- a/app/views/issues_panel/index.html.erb
+++ b/app/views/issues_panel/index.html.erb
@@ -106,6 +106,7 @@ function showIssueDescription(issue_element, description_element) {
   $.ajax({
     url: '<%= show_issue_description_path %>',
     data: { 'id': issue_id},
+    global: false,
     success: function(data) {
       if (data['description'] !== undefined && data['description'] != '') {
         description_element.html(data['description']);


### PR DESCRIPTION
## Overview

This pull request improves the behavior and user experience of issue card hover interactions in the `issues_panel` view. The main changes focus on introducing delays for showing and hiding issue descriptions, ensuring smoother UI transitions and preventing flickering when users quickly move their mouse over or away from issue cards.

## Verification

I confirmed the following behaviors after applying the changes (tested on Chrome browser):

- **Before:** The description tooltip flickered when moving the mouse quickly in and out of the subject link, and the global loading indicator appeared briefly before the description content was shown.  
- **After:** The tooltip display became smooth when hovering quickly over issue card subjects, and the loading indicator no longer appeared before the description was rendered.

| before | after |
|--------|------|
|  ![before-fix-description-tooltip-flicker](https://github.com/user-attachments/assets/a59012ad-3906-4282-b5a2-e91e3e1b82eb) |  ![after-fix-description-tooltip-flicker](https://github.com/user-attachments/assets/33651e30-c804-415f-843d-f55a921a968a) |

## Enhancements to issue card hover interactions

* Added a 500ms delay before showing the issue description when hovering over an issue card subject link, using a new `showTimer` variable to manage the timing.
* Added a 400ms delay before hiding the issue description when the mouse leaves the subject link, using a new `closeTimer` variable to prevent abrupt hiding.
* Replaced the single `timer` variable with separate `showTimer` and `closeTimer` variables for clearer and more reliable management of show/hide timing.

## AJAX request improvement

* Set `global: false` in the AJAX request for showing the issue description, preventing global AJAX event handlers from being triggered for this request.
* This avoids the brief display of the global loading indicator before the description is shown, which previously caused a noticeable flicker effect.