### PR TITLE
Fix flicker when closing issue description popup

### DIFF
--- a/app/views/issues_panel/index.html.erb
+++ b/app/views/issues_panel/index.html.erb
@@ -99,6 +99,7 @@ function showIssueDescription(issue_element, description_element) {
   var mouse_x = issue_element.offset().left;
   var mouse_y = issue_element.offset().top;
 
+  description_element.hide();
   description_element.css('left', (mouse_x + 'px'));
   description_element.css('top', (mouse_y + 'px'));
   description_element.html('');
@@ -138,8 +139,8 @@ function showIssueDescription(issue_element, description_element) {
   });
 }
 function hideIssueDescription() {
-  $('#issue_panel_issue_description').html('');
   $('#issue_panel_issue_description').hide();
+  $('#issue_panel_issue_description').html('');
 }
 function loadCardFunctions(){
   let closeTimer;


### PR DESCRIPTION
## Overview

When hovering over an issue subject to show the issue description popup, then moving the pointer to another issue subject, the previously displayed popup briefly shows a partial flash as it closes. 

https://github.com/user-attachments/assets/b281cfad-ef16-408a-9c17-5ed8a8a1aec9

This PR fixes that issue.

## Details

The issue seems to occur because the popup remains in a visible state while the next popup is being prepared. As a result, an incomplete popup is briefly rendered before the content and position are finalized.

This PR changes the behavior so that the popup only becomes visible once everything is ready.

**After fix:**

https://github.com/user-attachments/assets/07ba5f27-798f-4db1-a9a3-c7f19757ef3a

## Checklist

* [x] Verified the fix in Chrome, Firefox, and Safari
