### PR TITLE
Update test targets to the latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on:
   push:
+    branches:
+      - 'master'
+      - 'dev*'
   pull_request:
   schedule:
     - cron: "0 23 * * 0-4"   # 08:00 JST, Monday to Friday


### PR DESCRIPTION
This PR updates test targets to the latest and addresses the followings:

* Add scheduled trigger to run tests regularly
* Remove obsolete condition that skips tests for master #66
* Update actions to the latest and pin to specific commit SHAs
* Prevent duplicate test runs when creating a PR from a branch in redmica/redmine_issues_panel