### PR TITLE
Enable to manual ordering

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,4 +35,6 @@ jobs:
       with:
         path: plugins/redmine_issues_panel
 
+    - run: bin/rails redmine:plugins:migrate NAME=redmine_issues_panel RAILS_ENV=test
+
     - run: bin/rails redmine:plugins:test NAME=redmine_issues_panel

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ This is a plugin for Redmine to display issues by statuses and change it's statu
 $ git clone https://github.com/redmica/redmine_issues_panel.git /path/to/redmine/plugins/redmine_issues_panel
 ```
 
+#### Migration (to add the new table)
+
+```
+$ bin/rails redmine:plugins:migrate NAME=redmine_issues_panel
+```
+
 ## How to activate the Issues Panel
 
 #### Check the 'Issues Panel' checkbox on the Project->Settings->Modules and save it.
@@ -34,6 +40,12 @@ $ bundle exec rake redmine:plugins:test NAME=redmine_issues_panel RAILS_ENV=test
 ```
 
 ## Uninstall
+
+#### Run the migration to remove the table.
+
+```
+$ bin/rails redmine:plugins:migrate NAME=redmine_issues_panel VERSION=0
+```
 
 #### Remove the plugin directory.
 

--- a/app/controllers/issues_panel_controller.rb
+++ b/app/controllers/issues_panel_controller.rb
@@ -71,6 +71,11 @@ class IssuesPanelController < ApplicationController
       elsif params[:query_id].blank? && session[session_key][:issues_num_per_row]
         @query.issues_num_per_row = session[session_key][:issues_num_per_row]
       end
+      if params[:set_filter] && params[:query] && params[:query][:enable_manual_ordering]
+        session[session_key][:enable_manual_ordering] = @query.enable_manual_ordering
+      elsif params[:query_id].blank? && session[session_key][:enable_manual_ordering]
+        @query.enable_manual_ordering = session[session_key][:enable_manual_ordering]
+      end
     end
     @issues_panel.query = @query
   end

--- a/app/models/issue_card_position.rb
+++ b/app/models/issue_card_position.rb
@@ -1,0 +1,16 @@
+class IssueCardPosition < ActiveRecord::Base
+  class << self
+    def update_positions!(ordered_issue_ids=[])
+      return if ordered_issue_ids.blank?
+      ordered_issue_positions = ordered_issue_ids.each_with_index.map { |id, i| { issue_id: id, position: i } }
+      opts = { update_only: %i[position] }
+      # :unique_by option is supported only by PostgreSQL and SQLite3
+      opts[:unique_by] = 'index_issue_card_positions_on_issue_id' if Redmine::Database.postgresql? || Redmine::Database.sqlite?
+      self.upsert_all(ordered_issue_positions, **opts)
+    end
+  end
+
+  def to_s
+    position.to_s
+  end
+end

--- a/app/views/issues_panel/_query_form.html.erb
+++ b/app/views/issues_panel/_query_form.html.erb
@@ -45,8 +45,15 @@
             <%= hidden_field_tag 'selected_query_issues_num_per_row', @query.issues_num_per_row %>
             <%= select_tag 'query[issues_num_per_row]', options_for_select([1, 2, 3], @query.issues_num_per_row) %>
           </div>
+          <div>
+            <div class="field"><%= l(:field_enable_manual_ordering) %></div>
+            <label for='query_enable_manual_ordering'>
+              <%= hidden_field_tag 'query[enable_manual_ordering]', '0' %>
+              <%= check_box_tag 'query[enable_manual_ordering]', '1', @query.enable_manual_ordering?, :onchange => 'toggleSortSelection()' %>
+            </label>
+          </div>
           <% if @query.sortable_columns.any? %>
-            <div>
+            <div id="sort">
               <div class="field"><label for='sort'><%= l(:label_sort) %></label></div>
               <div>
                 <% 3.times do |i| %>
@@ -100,7 +107,8 @@ $(function ($) {
     } else {
       $('table#list-definition').hide();
     }
-  })
+  });
+  toggleSortSelection();
 });
 
 <% end %>

--- a/app/views/issues_panel/index.html.erb
+++ b/app/views/issues_panel/index.html.erb
@@ -63,6 +63,20 @@ function loadDraggableSettings() {
     });
   });
 }
+function moveIssueCard(issue_card, receiver, ordered_issue_ids=[]) {
+  $.ajax({
+    url: '<%= move_issue_card_path(:format => 'js') %>',
+    type: 'put',
+    data: {
+      'id': issue_card.attr('data-issue-id'),
+      <%= @project ? ("'project_id': #{@project.id},").html_safe : '' %>
+      'status_id': receiver.attr('data-status-id'),
+      'group_key': receiver.attr('data-group-key'),
+      'group_value': receiver.attr('data-group-value'),
+      'ordered_issue_ids': ordered_issue_ids
+      }
+  });
+}
 function loadDroppableSetting() {
   $(".issue-card-receiver").droppable({
     accept: ".issue-card",
@@ -78,21 +92,32 @@ function loadDroppableSetting() {
             (typeof(new_group_value) === "undefiend" || org_group_value==new_group_value)) {
           return $(ui.draggable).addClass('drag-revert');
         } else {
-          $.ajax({
-            url: '<%= move_issue_card_path(:format => 'js') %>',
-            type: 'put',
-            data: {
-              'id': ui.draggable.attr('data-issue-id'),
-              <%= @project ? ("'project_id': #{@project.id},").html_safe : '' %>
-              'status_id': $(this).attr('data-status-id'),
-              'group_key': $(this).attr('data-group-key'),
-              'group_value': $(this).attr('data-group-value')
-            }
-          });
+          moveIssueCard(ui.draggable, $(this));
         }
       }
     }
   });
+}
+function loadSortableSetting() {
+  $(".issue-card-receiver").sortable({
+    items: ".issue-card:not(.add-issue-card)",
+    connectWith: '.issue-card-receiver',
+    revert: true,
+    start: function(event, ui) {
+      ui.item.css({ opacity: 0.9 });
+      ui.placeholder.height(ui.item.height());
+    },
+    activate: function() { $('.hascontextmenu').removeClass('context-menu-selection cm-last');contextMenuHide();hideIssueDescription(); },
+    update: function(event, ui) {
+      var current_receiver = ui.item.parents('.issue-card-receiver')[0];
+      if (this !== current_receiver) return; // do nothing if the update event is not fired in the current receiver
+      var ordered_issue_ids = [];
+      $(this).find('.issue-card:not(.add-issue-card)').each(function(_, elem) {
+        ordered_issue_ids.push($(elem).attr('data-issue-id'));
+      });
+      moveIssueCard(ui.item, $(this), ordered_issue_ids);
+    }
+  }).disableSelection();
 }
 function showIssueDescription(issue_element, description_element) {
   var issue_id = issue_element.attr('href').split('/').at(-1)
@@ -193,8 +218,12 @@ function loadCardFunctions(){
   });
 }
 $(document).ready(function(){
+  <% if @query.enable_manual_ordering? %>
+  loadSortableSetting();
+  <% else %>
   loadDraggableSettings();
   loadDroppableSetting();
+  <% end %>
   loadCardFunctions();
   hideIssueDescription();
 });

--- a/app/views/issues_panel/move_issue_card.js.erb
+++ b/app/views/issues_panel/move_issue_card.js.erb
@@ -1,5 +1,5 @@
 <% @issues_panel.view = self %>
-<% if @issue_card.saved_changes? %>
+<% if @issue_card.saved_changes? || @issue_card.reordered? %>
   /// remove issue card
   $('#issue-card-<%= @issue_card.id %>').remove();
   // refresh status total
@@ -16,11 +16,18 @@
   // restore background-color
   contextMenuAddSelection($('#issue-<%= @issue_card.id %>'));
   loadCardFunctions();
-  loadDraggableSettings();
+  <% unless @issues_panel.query.enable_manual_ordering? %>
+    loadDraggableSettings();
+  <% end %>
 <% else %>
   <% if flash[:error].present? %>
   alert('<%= raw(escape_javascript(flash[:error])) %>');
   <% end %>
-  // revart issue card
-  $('#issue-card-<%= @issue_card.id %>').animate( {left: 0, top: 0}, 500 );
+  <% if @issues_panel.query.enable_manual_ordering? %>
+    // cancel card reordering
+    $('.issue-card-receiver').sortable('cancel');
+  <% else %>
+    // revart issue card
+    $('#issue-card-<%= @issue_card.id %>').animate( {left: 0, top: 0}, 500 );
+  <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,8 @@ en:
   notice_failed_to_move_issue: "Failed to move issue."
   label_assign_to_me: "Assign to me"
   field_issues_num_per_row: "Issues num per row"
+  field_issue_card_position: "Issue card position"
+  field_enable_manual_ordering: "Enable manual ordering"
 
   project_module_issues_panel: "Issues Panel"
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,8 @@ ja:
   notice_failed_to_move_issue: "チケットの移動に失敗しました。"
   label_assign_to_me: "自分に割り当て"
   field_issues_num_per_row: "一行ごとのチケット数"
+  field_issue_card_position: "カードの位置"
+  field_enable_manual_ordering: "手動で並び替え"
 
   project_module_issues_panel: "チケットパネル"
 

--- a/db/migrate/20250901151155_create_issue_card_positions.rb
+++ b/db/migrate/20250901151155_create_issue_card_positions.rb
@@ -7,5 +7,6 @@ class CreateIssueCardPositions < ActiveRecord::Migration[7.2]
       t.column :updated_on, :datetime, null: false
     end
     add_index :issue_card_positions, :issue_id, name: 'index_issue_card_positions_on_issue_id', unique: true
+    add_index :issue_card_positions, :position, name: 'index_issue_card_positions_on_position'
   end
 end

--- a/db/migrate/20250901151155_create_issue_card_positions.rb
+++ b/db/migrate/20250901151155_create_issue_card_positions.rb
@@ -1,0 +1,11 @@
+class CreateIssueCardPositions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :issue_card_positions do |t|
+      t.column :issue_id, :integer, null: false
+      t.column :position, :integer, null: false, default: 0
+      t.column :created_on, :datetime, null: false
+      t.column :updated_on, :datetime, null: false
+    end
+    add_index :issue_card_positions, :issue_id, name: 'index_issue_card_positions_on_issue_id', unique: true
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../lib/redmine_issues_panel/queries_controller_patch', __FILE__)
 require File.expand_path('../lib/redmine_issues_panel/view_hook', __FILE__)
+require File.expand_path('../lib/redmine_issues_panel/issue_patch', __FILE__)
 require File.expand_path('../lib/redmine_issues_panel/issue_query_patch', __FILE__)
 
 Redmine::Plugin.register :redmine_issues_panel do

--- a/lib/redmine/helpers/issues_panel.rb
+++ b/lib/redmine/helpers/issues_panel.rb
@@ -24,6 +24,7 @@ module Redmine
       def query=(query)
         @query = query
         query.available_columns.delete_if { |c| c.name == :tracker }
+        query.use_on_issues_panel = true
         @truncated = @query.issue_count.to_i > @issues_limit.to_i
       end
 

--- a/lib/redmine_issues_panel/issue_patch.rb
+++ b/lib/redmine_issues_panel/issue_patch.rb
@@ -1,0 +1,13 @@
+require 'issue'
+
+module RedmineIssuesPanel
+  module IssuePatch
+    def self.included(base)
+      base.class_eval do
+        has_one :issue_card_position, dependent: :destroy, foreign_key: :issue_id
+      end
+    end
+  end
+end
+
+Issue.include RedmineIssuesPanel::IssuePatch

--- a/lib/redmine_issues_panel/issue_query_patch.rb
+++ b/lib/redmine_issues_panel/issue_query_patch.rb
@@ -6,6 +6,8 @@ module RedmineIssuesPanel
       base.send(:prepend, InstanceMethods)
       base.class_eval do
         #unloadable
+        attribute :use_on_issues_panel, :boolean, default: false
+        self.available_columns << QueryColumn.new(:issue_card_position, :sortable => "#{IssueCardPosition.table_name}.position")
       end
     end
 
@@ -16,7 +18,33 @@ module RedmineIssuesPanel
           params[:issues_num_per_row] ||
             (params[:query] && params[:query][:issues_num_per_row]) ||
             options[:issues_num_per_row]
+        self.enable_manual_ordering =
+          params[:enable_manual_ordering] ||
+            (params[:query] && params[:query][:enable_manual_ordering]) ||
+            options[:enable_manual_ordering]
         self
+      end
+
+      def base_scope
+        s = super
+        if (self.use_on_issues_panel? && self.enable_manual_ordering?) ||
+            (self.column_names && self.column_names.include?(:issue_card_position))
+          s = s.includes(:issue_card_position)
+        end
+        s
+      end
+
+      def issues(options={})
+        if self.enable_manual_ordering?
+          options[:order] = []
+          if Redmine::Database.postgresql?
+            options[:order] << Arel.sql("#{IssueCardPosition.table_name}.position ASC NULLS FIRST")
+          else
+            options[:order] << Arel.sql("#{IssueCardPosition.table_name}.position ASC")
+          end
+          options[:order] << Arel.sql("#{Issue.table_name}.id DESC")
+        end
+        super(options)
       end
 
       def issues_num_per_row
@@ -26,6 +54,23 @@ module RedmineIssuesPanel
 
       def issues_num_per_row=(arg)
         options[:issues_num_per_row] = arg ? arg.to_i : 1
+      end
+
+      def enable_manual_ordering
+        options[:enable_manual_ordering]
+      end
+
+      def enable_manual_ordering?
+        return false unless self.use_on_issues_panel?
+        if self.enable_manual_ordering.nil?
+          self.new_record? ? true : false
+        else
+          self.enable_manual_ordering.to_s == '1'
+        end
+      end
+
+      def enable_manual_ordering=(arg)
+        options[:enable_manual_ordering] = (arg.to_s == '0' ? '0' : '1')
       end
     end
   end

--- a/lib/redmine_issues_panel/view_hook.rb
+++ b/lib/redmine_issues_panel/view_hook.rb
@@ -3,8 +3,19 @@ module RedmineIssuesPanel
     def view_layouts_base_html_head(context={})
       query = context[:controller].instance_variable_get(:'@query')
       html = +''
+      js = <<~JS
+        function toggleSortSelection() {
+          if ($('input#query_enable_manual_ordering').is(':checked')) {
+            $('#sort').hide();
+          } else {
+            $('#sort').show();
+          }
+        }
+      JS
+      html << javascript_tag(js)
       if (context[:controller] && context[:controller].is_a?(QueriesController)) &&
         (context[:request] && context[:request].try(:params).is_a?(Hash) && context[:request].params['issues_panel'])
+        query.use_on_issues_panel = true
         js = <<~JS
           $(document).ready(function(){
             var selector = '#{select_tag('query[issues_num_per_row]', options_for_select([1, 2, 3], (query && query.issues_num_per_row)).gsub("\n",'').html_safe)}';
@@ -12,6 +23,12 @@ module RedmineIssuesPanel
             $('p.block_columns').remove();
             $('p.totable_columns').remove();
             $('p#group_by').after('<p id="issues_num_per_row"><label for="query_issues_num_per_row">#{l(:field_issues_num_per_row)}</label>' + selector + '</p>');
+            var checkbox = '#{hidden_field_tag('query[enable_manual_ordering]', 0, id: nil)}#{check_box_tag('query[enable_manual_ordering]', 1, (query && query.enable_manual_ordering?))}';
+            $('p#issues_num_per_row').after('<p id="enable_manual_ordering"><label for="query_enable_manual_ordering">#{l(:field_enable_manual_ordering)}</label>' + checkbox + '</p>');
+            toggleSortSelection();
+            $('input#query_enable_manual_ordering').on('change', function(){
+              toggleSortSelection();
+            });
           });
         JS
         html << javascript_tag(js)

--- a/test/functional/issues_panel_controller_test.rb
+++ b/test/functional/issues_panel_controller_test.rb
@@ -94,7 +94,6 @@ class IssuesPanelControllerTest < ActionController::TestCase
     assert_match "$('#issues-count-on-status-5').html('4')", response.body
     assert_match "$('.issues-count-on-group').html('0');", response.body
     assert_match "$('#issues-count-on-group-').html('4');", response.body
-    assert_match "loadDraggableSettings();", response.body
   end
 
   def test_move_issue_card_but_record_not_found
@@ -103,7 +102,7 @@ class IssuesPanelControllerTest < ActionController::TestCase
     }
     assert_response :success
     assert_match "alert('#{I18n.t(:error_issue_not_found_in_project)}')", response.body
-    assert_match "('#issue-card-').animate( {left: 0, top: 0}, 500 );", response.body
+    assert_match "$('.issue-card-receiver').sortable('cancel');", response.body
   end
 
   def test_move_issue_card_but_unauthorized
@@ -113,7 +112,7 @@ class IssuesPanelControllerTest < ActionController::TestCase
     }
     assert_response :success
     assert_match "alert('#{I18n.t(:notice_not_authorized_to_change_this_issue)}')", response.body
-    assert_match "('#issue-card-1').animate( {left: 0, top: 0}, 500 );", response.body
+    assert_match "$('.issue-card-receiver').sortable('cancel');", response.body
   end
 
   def test_move_issue_card_but_exception_raised
@@ -124,7 +123,7 @@ class IssuesPanelControllerTest < ActionController::TestCase
     }
     assert_response :success
     assert_match "alert('#{error_message_on_move}')", response.body
-    assert_match "('#issue-card-1').animate( {left: 0, top: 0}, 500 );", response.body
+    assert_match "$('.issue-card-receiver').sortable('cancel');", response.body
   end
 
   def assert_modal_issue_card()

--- a/test/unit/issue_card_position_test.rb
+++ b/test/unit/issue_card_position_test.rb
@@ -1,0 +1,34 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class IssueCardPositionTest < ActiveSupport::TestCase
+  def setup
+    User.current = User.find(1)
+  end
+
+  def test_update_positions
+    IssueCardPosition.delete_all
+    assert_equal 0, IssueCardPosition.count
+
+    # insert new positions
+    IssueCardPosition.update_positions!([3, 1, 2])
+    assert_equal 3, IssueCardPosition.count
+    assert_equal 0, IssueCardPosition.find_by(issue_id: 3).position
+    assert_equal 1, IssueCardPosition.find_by(issue_id: 1).position
+    assert_equal 2, IssueCardPosition.find_by(issue_id: 2).position
+
+    # update existing positions
+    IssueCardPosition.update_positions!([2, 3, 1])
+    assert_equal 3, IssueCardPosition.count
+    assert_equal 0, IssueCardPosition.find_by(issue_id: 2).position
+    assert_equal 1, IssueCardPosition.find_by(issue_id: 3).position
+    assert_equal 2, IssueCardPosition.find_by(issue_id: 1).position
+
+    # mixed existing and new positions
+    IssueCardPosition.update_positions!([4, 1, 3, 5])
+    assert_equal 5, IssueCardPosition.count
+    assert_equal 0, IssueCardPosition.find_by(issue_id: 4).position
+    assert_equal 1, IssueCardPosition.find_by(issue_id: 1).position
+    assert_equal 2, IssueCardPosition.find_by(issue_id: 3).position
+    assert_equal 3, IssueCardPosition.find_by(issue_id: 5).position
+  end
+end


### PR DESCRIPTION
This pull request introduces a new feature to support manual ordering of issue cards in the Issues Panel plugin for Redmine. It adds a new database table to track card positions, updates the UI to allow toggling manual ordering, and modifies backend logic to handle ordering and sorting of issue cards. The changes also include relevant migration instructions and localization updates.

![poc_for_issue_card_manual_ordering](https://github.com/user-attachments/assets/20e8c0a7-80e0-492a-bcb6-73d6f228b997)

## Details

**Manual Ordering Feature**

* Added a new model `IssueCardPosition` and corresponding migration to store the position of each issue card, along with logic to update positions efficiently when cards are reordered. [[1]](diffhunk://#diff-9c65be5834b33461e3a36e5732372ff0161ddef9aa3486223421f230904cb466R1-R15) [[2]](diffhunk://#diff-163b11f8caf3deb0ea82e68512080129c07c9cde75c03b9eae36c1498316a21dR1-R11)
* Updated `IssueCard` and backend logic to handle reordering, including a new `reorderd` attribute and transaction logic for saving reordered cards. [[1]](diffhunk://#diff-295e9b40f8d63203f67658547c065ac4950d970440f680e3156be64663f95ce4R2) [[2]](diffhunk://#diff-295e9b40f8d63203f67658547c065ac4950d970440f680e3156be64663f95ce4R27-R36)
* Patched the `Issue` and `IssueQuery` models to associate issue cards with their positions and to support sorting by manual order when enabled. [[1]](diffhunk://#diff-3a5eabcfb7c0597089dfc7aa2323937b5c21886e485e4cbc614964e31b839c70R1-R13) [[2]](diffhunk://#diff-af96b23d2901c9dad4c08b5015d0ddab0f20b1e77eb9339f85150a78f5508439R9-R10) [[3]](diffhunk://#diff-af96b23d2901c9dad4c08b5015d0ddab0f20b1e77eb9339f85150a78f5508439L19-R46) [[4]](diffhunk://#diff-af96b23d2901c9dad4c08b5015d0ddab0f20b1e77eb9339f85150a78f5508439R57-R73)

**User Interface Enhancements**

* Added a checkbox to the query form for enabling manual ordering, with dynamic UI logic to show/hide sorting options based on the checkbox state. [[1]](diffhunk://#diff-23366a1c6b5bcc3a18c59817b874f72e4d2f81a63e1887924cb64a6523cca1b4L48-R56) [[2]](diffhunk://#diff-16bf4b6380188e77a74c96ec1b9c8d716ae83d0efe7fb4ce16a6fe8c0357b834R6-R31)
* Updated JavaScript to support drag-and-drop sorting of issue cards when manual ordering is enabled, and fallback to previous behavior otherwise. [[1]](diffhunk://#diff-56b3f6339a5d38e0e708dd14641862a4f164363399c7c9d45650ec431883fe89R66-R79) [[2]](diffhunk://#diff-56b3f6339a5d38e0e708dd14641862a4f164363399c7c9d45650ec431883fe89L81-R120) [[3]](diffhunk://#diff-56b3f6339a5d38e0e708dd14641862a4f164363399c7c9d45650ec431883fe89R207-R212) [[4]](diffhunk://#diff-f91468df4047d5bf8eaf214b236ee5dc0f01b1a2308a8b0b573ad55944e0117bL2-R2) [[5]](diffhunk://#diff-f91468df4047d5bf8eaf214b236ee5dc0f01b1a2308a8b0b573ad55944e0117bR19-R33)

**Documentation and Localization**

* Updated the README with migration instructions for installing and uninstalling the new table. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R23-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R44-R49)
* Added new localization strings for manual ordering and card position in both English and Japanese. [[1]](diffhunk://#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7R9-R10) [[2]](diffhunk://#diff-b85e8d609d1ca8ea9aef96cf26c7011d39b5dd2e7de34dd4c52d931979917508R9-R10)

**Other Backend and Test Updates**

* Ensured issue queries use the new ordering logic and updated tests to verify the new sortable behavior. [[1]](diffhunk://#diff-9e7a9425a2dc3081032e3289cf482f6807a3acc93dcefd56f241317fbb3e7433R27) [[2]](diffhunk://#diff-a5d60ba05e165607153ebebad3769c6d79ec75064e6be62ac6f1920f4686f029L97-R97)

These changes collectively enable users to manually order issue cards in the panel, persist their positions, and toggle between manual and automatic sorting as needed.

## Checklist

* [x] All plugin test cases passed successfully
* [x] Verified the feature works correctly in Chrome, Firefox, and Safari