### PR TITLE
Apply default query to issues panel

### DIFF
--- a/app/controllers/issues_panel_controller.rb
+++ b/app/controllers/issues_panel_controller.rb
@@ -76,6 +76,8 @@ class IssuesPanelController < ApplicationController
     @issues_panel.query = @query
   end
 
+  # This method is based on IssuesController#retrieve_default_query
+  # and should be kept in sync with the Redmine core implementation.
   def retrieve_default_query(use_session)
     return if params[:query_id].present?
     return if api_request?

--- a/app/controllers/issues_panel_controller.rb
+++ b/app/controllers/issues_panel_controller.rb
@@ -62,7 +62,9 @@ class IssuesPanelController < ApplicationController
 
   def retrieve_issue_panel(params={})
     @issues_panel = Redmine::Helpers::IssuesPanel.new(params)
-    retrieve_query
+    use_session = true
+    retrieve_default_query(use_session)
+    retrieve_query(IssueQuery, use_session)
     # retrieve optional query filter in session
     session_key = IssueQuery.name.underscore.to_sym
     if session[session_key]
@@ -73,5 +75,26 @@ class IssuesPanelController < ApplicationController
       end
     end
     @issues_panel.query = @query
+  end
+
+  def retrieve_default_query(use_session)
+    return if params[:query_id].present?
+    return if api_request?
+    return if params[:set_filter]
+
+    if params[:without_default].present?
+      params[:set_filter] = 1
+      return
+    end
+
+    if !params[:set_filter] && use_session && session[:issue_query]
+      # Don't apply the default query if a valid query id is set in the session
+      query_id, project_id = session[:issue_query].values_at(:id, :project_id)
+      return if query_id && project_id == @project&.id && IssueQuery.exists?(id: query_id)
+    end
+
+    if (default_query = IssueQuery.default(project: @project))
+      params[:query_id] = default_query.id
+    end
   end
 end

--- a/app/controllers/issues_panel_controller.rb
+++ b/app/controllers/issues_panel_controller.rb
@@ -62,9 +62,8 @@ class IssuesPanelController < ApplicationController
 
   def retrieve_issue_panel(params={})
     @issues_panel = Redmine::Helpers::IssuesPanel.new(params)
-    use_session = true
-    retrieve_default_query(use_session)
-    retrieve_query(IssueQuery, use_session)
+    retrieve_default_query(true)
+    retrieve_query(IssueQuery, true)
     # retrieve optional query filter in session
     session_key = IssueQuery.name.underscore.to_sym
     if session[session_key]

--- a/test/functional/issues_panel_controller_test.rb
+++ b/test/functional/issues_panel_controller_test.rb
@@ -37,12 +37,42 @@ class IssuesPanelControllerTest < ActionController::TestCase
 
     # query form
     assert_query_form
+    assert_issues_panel_for_query_100
+  end
 
+  def test_index_applies_project_default_query
+    @project = Project.find(1)
+    @project.enabled_modules << EnabledModule.new(name: 'issues_panel')
+    @project.default_issue_query = IssueQuery.find(100)
+    @project.save!
+
+    get :index, :params => {
+      :project_id => 1
+    }
+    assert_response :success
+
+    assert_query_form
+    assert_issues_panel_for_query_100
+  end
+
+  def assert_query_form
+    # query form
+    assert_select 'form#query_form' do
+      assert_select 'div#query_form_with_buttons.hide-when-print' do
+        assert_select 'div#query_form_content' do
+          assert_select 'fieldset#filters.collapsible'
+          assert_select 'fieldset#options'
+        end
+        assert_select 'p.buttons'
+      end
+    end
+  end
+
+  def assert_issues_panel_for_query_100
     issue_ids_on_status_1 = [1, 3, 5, 6, 7, 9, 10, 13, 14]
     issue_ids_on_status_2 = [2]
     issue_ids_on_status_5 = [8, 11, 12]
 
-    # issues panel
     assert_select 'table#issues_panel.issues-panel' do
       assert_select 'thead' do
         assert_select 'tr' do
@@ -61,19 +91,6 @@ class IssuesPanelControllerTest < ActionController::TestCase
         assert_select 'td.issue-card-receiver[data-status-id=5]' do
           assert_issue_cards(issue_ids_on_status_5)
         end
-      end
-    end
-  end
-
-  def assert_query_form
-    # query form
-    assert_select 'form#query_form' do
-      assert_select 'div#query_form_with_buttons.hide-when-print' do
-        assert_select 'div#query_form_content' do
-          assert_select 'fieldset#filters.collapsible'
-          assert_select 'fieldset#options'
-        end
-        assert_select 'p.buttons'
       end
     end
   end

--- a/test/functional/issues_panel_controller_test.rb
+++ b/test/functional/issues_panel_controller_test.rb
@@ -40,15 +40,62 @@ class IssuesPanelControllerTest < ActionController::TestCase
     assert_issues_panel_for_query_100
   end
 
-  def test_index_applies_project_default_query
+  def test_index_should_retrieve_default_query
     @project = Project.find(1)
     @project.enabled_modules << EnabledModule.new(name: 'issues_panel')
-    @project.default_issue_query = IssueQuery.find(100)
     @project.save!
+    query = IssueQuery.find(100)
+    IssueQuery.stubs(:default).with(project: @project).returns(query)
+    get :index, :params => { :project_id => 1 }
+    assert_response :success
 
-    get :index, :params => {
-      :project_id => 1
-    }
+    assert_query_form
+    assert_issues_panel_for_query_100
+  end
+
+  def test_index_should_ignore_default_query_with_without_default
+    @project = Project.find(1)
+    @project.enabled_modules << EnabledModule.new(name: 'issues_panel')
+    @project.save!
+    query = IssueQuery.find(5)
+    IssueQuery.stubs(:default).with(project: @project).returns(query)
+    get :index, :params => { :project_id => 1, :without_default => '1' }
+    assert_response :success
+    assert_select 'h2', :text => I18n.t(:label_issues_panel_plural)
+  end
+
+  def test_index_should_ignore_default_query_with_set_filter_and_without_default
+    @project = Project.find(1)
+    @project.enabled_modules << EnabledModule.new(name: 'issues_panel')
+    @project.save!
+    query = IssueQuery.find(5)
+    IssueQuery.stubs(:default).with(project: @project).returns(query)
+    get :index, :params => { :project_id => 1, :set_filter => '1', :without_default => '1' }
+    assert_response :success
+    assert_select 'h2', :text => I18n.t(:label_issues_panel_plural)
+  end
+
+  def test_index_should_ignore_default_query_with_valid_session_query
+    @project = Project.find(1)
+    @project.enabled_modules << EnabledModule.new(name: 'issues_panel')
+    @project.save!
+    default_query = IssueQuery.find(5)
+    IssueQuery.stubs(:default).with(project: @project).returns(default_query)
+    session_query = IssueQuery.find(1)
+    @request.session[:issue_query] = { :id => session_query.id, :project_id => @project.id }
+    get :index, :params => { :project_id => 1 }
+    assert_response :success
+    assert_select 'h2', :text => session_query.name
+  end
+
+  def test_index_should_use_default_query_with_invalid_session_query
+    @project = Project.find(1)
+    @project.enabled_modules << EnabledModule.new(name: 'issues_panel')
+    @project.save!
+    query = IssueQuery.find(100)
+    IssueQuery.stubs(:default).with(project: @project).returns(query)
+    @request.session[:issue_query] = { :id => 999999, :project_id => @project.id }
+    get :index, :params => { :project_id => 1 }
     assert_response :success
 
     assert_query_form


### PR DESCRIPTION
## Summary

This PR fixes the issue where the default query was not applied in the Issues Panel.

`IssuesPanelController` was not applying the default query because it lacked a call to `retrieve_default_query`, which was added to `IssuesController` in Redmine core. Since this method is a private method of `IssuesController` and `IssuesPanelController` does not inherit from it, `retrieve_default_query` has been re-implemented in `IssuesPanelController`.

## Changes

- Add `retrieve_default_query` to `IssuesPanelController` and call it in `retrieve_issue_panel`
- Add tests for default query behavior covering the following cases:
  - Default query is applied
  - Default query is ignored when `without_default` is given
  - Default query is ignored when both `set_filter` and `without_default` are given
  - Default query is ignored when a valid query is stored in session
  - Default query is applied when the session query is invalid

## Verification

- All tests pass
- Confirmed that the default query is correctly applied in the Issues Panel
  - eCookbook project settings with Open issues by priority and tracker set as the default issue query.
    <img width="1920" height="860" alt="project-settings-default-issue-query-ecookbook-wide" src="https://github.com/user-attachments/assets/87d91632-607d-459d-8990-2c00644a7874" />

  - eCookbook Issues Panel automatically applying the project default query on initial load.
    <img width="1920" height="860" alt="project-issues-panel-default-query-applied-ecookbook-wide-v2" src="https://github.com/user-attachments/assets/dc009cae-0492-46fd-bb8f-bb94b707765b" />

  - eCookbook Issues Panel after clearing the default query from the sidebar.
    <img width="1920" height="860" alt="project-issues-panel-without-default-after-clear-ecookbook-wide-v2" src="https://github.com/user-attachments/assets/2e5ad590-fdb3-441d-bc65-5c8371607b31" />