### PR TITLE
Prevent unintended drag start on card click

### DIFF
--- a/app/views/issues_panel/index.html.erb
+++ b/app/views/issues_panel/index.html.erb
@@ -44,6 +44,7 @@ function loadDraggableSettings() {
     var movable_area = $(id).parent('td').attr('data-movable-area');
     $(id).draggable({
       containment: movable_area,
+      distance: 10,
       snap: ".issue-card-receiver",
       snapMode: "inner",
       revert: function(ui) {


### PR DESCRIPTION
## Summary

Clicking a card in the Issues Panel (e.g. the issue title link) was sometimes treated as a drag instead of a click. Even empty areas of a card would occasionally show the drag-start visual effect (rotation, opacity change) on a plain click.

`draggable()` was applied to the whole `.issue-card` without a `distance` option, so the jQuery UI default of 1px was used. Any tiny pointer movement during a click was enough to be treated as a drag start, which also suppresses the subsequent `click` event on the element. This is easy to trigger on devices where a click naturally involves a small amount of pointer movement, such as trackpads.

## Changes

- Add `distance: 10` to the `draggable()` options in `loadDraggableSettings()` so a drag only starts once the pointer has moved at least 10px.

## Verification

- All existing tests pass
- Confirmed that clicking a card title link, and clicking an empty area of a card, no longer triggers the drag visual effect
- Confirmed that intentionally dragging a card to move it between statuses/groups still works as before
